### PR TITLE
[#5] 책 조회 페이징 API 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ rebel.xml
 
 /master/
 /slave/
+
+# Ignore schema sql
+/src/main/resources/schema.sql

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ rebel.xml
 
 # Ignore schema sql
 /src/main/resources/schema.sql
+
+# Ignore dummy batch query
+**/dummy/

--- a/src/main/java/com/flab/book_challenge/BookChallengeApplication.java
+++ b/src/main/java/com/flab/book_challenge/BookChallengeApplication.java
@@ -2,12 +2,14 @@ package com.flab.book_challenge;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BookChallengeApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BookChallengeApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BookChallengeApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/flab/book_challenge/book/BookMapper.java
+++ b/src/main/java/com/flab/book_challenge/book/BookMapper.java
@@ -2,6 +2,9 @@ package com.flab.book_challenge.book;
 
 import com.flab.book_challenge.book.domain.Book;
 import com.flab.book_challenge.book.response.BookDetailResponse;
+import com.flab.book_challenge.book.response.BooksResponse;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 
 public final class BookMapper {
 
@@ -16,7 +19,26 @@ public final class BookMapper {
             .build();
     }
 
-    public static BookDetailResponse toResponse(long id, String bookCode, String name, int pageCount) {
-        return new BookDetailResponse(id, bookCode, name, pageCount);
+    public static BookDetailResponse toResponse(Book book) {
+        return BookDetailResponse.builder()
+            .id(book.getId())
+            .bookCode(book.getBookCode())
+            .name(book.getName())
+            .pageCount(book.getPageCount())
+            .build();
+    }
+
+    public static BooksResponse toResponse(Page<Book> books) {
+        return BooksResponse.builder()
+            .pageNumber(books.getPageable().getPageNumber())
+            .size(books.getSize())
+            .totalElementSize(books.getTotalElements())
+            .totalPageSize(books.getTotalPages())
+            .hasNext(books.hasNext())
+            .data(books.getContent().stream()
+                .map(BookMapper::toResponse)
+                .collect(Collectors.toList())
+            )
+            .build();
     }
 }

--- a/src/main/java/com/flab/book_challenge/book/BookMapper.java
+++ b/src/main/java/com/flab/book_challenge/book/BookMapper.java
@@ -25,6 +25,7 @@ public final class BookMapper {
             .bookCode(book.getBookCode())
             .name(book.getName())
             .pageCount(book.getPageCount())
+            .createAt(book.getCreatedAt())
             .build();
     }
 

--- a/src/main/java/com/flab/book_challenge/book/controller/BookController.java
+++ b/src/main/java/com/flab/book_challenge/book/controller/BookController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,10 +36,10 @@ public class BookController {
     @Operation(summary = "책 전체 조회 (페이징)", tags = "Book")
     @GetMapping
     public ResponseEntity<ApiResponse<BooksResponse>> getBooks(
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size
+        @PageableDefault(size = 100) Pageable pageable,
+        @RequestParam(defaultValue = "LATEST") BookSortType sortType
     ) {
-        return ResponseEntity.ok(new ApiResponse<>(bookService.getBooks(page, size)));
+        return ResponseEntity.ok(new ApiResponse<>(bookService.getBooks(pageable, sortType)));
     }
 
     @Operation(summary = "책 검색", tags = "Book")

--- a/src/main/java/com/flab/book_challenge/book/controller/BookController.java
+++ b/src/main/java/com/flab/book_challenge/book/controller/BookController.java
@@ -4,6 +4,7 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
+import com.flab.book_challenge.book.response.BooksResponse;
 import com.flab.book_challenge.book.service.BookService;
 import com.flab.book_challenge.common.header.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,10 +31,13 @@ public class BookController {
 
     private final BookService bookService;
 
-    @Operation(summary = "책 전체 조회", tags = "Book")
+    @Operation(summary = "책 전체 조회 (페이징)", tags = "Book")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<BookDetailResponse>>> getBooks() {
-        return ResponseEntity.ok(new ApiResponse<>(bookService.getBooks()));
+    public ResponseEntity<ApiResponse<BooksResponse>> getBooks(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(bookService.getBooks(page, size)));
     }
 
     @Operation(summary = "책 검색", tags = "Book")

--- a/src/main/java/com/flab/book_challenge/book/controller/BookSortType.java
+++ b/src/main/java/com/flab/book_challenge/book/controller/BookSortType.java
@@ -1,0 +1,21 @@
+package com.flab.book_challenge.book.controller;
+
+import static com.flab.book_challenge.common.exception.ErrorStatus.BOOK_SORT_NOT_FOUND;
+
+import com.flab.book_challenge.common.exception.GeneralException;
+import org.springframework.data.domain.Sort;
+
+public enum BookSortType {
+    LATEST,
+    PAGE_COUNT,
+    BOOK_NAME;
+
+    public static Sort getSort(BookSortType sortType) {
+        return switch (sortType) {
+            case LATEST -> Sort.by(Sort.Direction.DESC, "createdAt");
+            case PAGE_COUNT -> Sort.by(Sort.Direction.DESC, "pageCount");
+            case BOOK_NAME -> Sort.by(Sort.Direction.ASC, "name");
+            default -> throw new GeneralException(BOOK_SORT_NOT_FOUND);
+        };
+    }
+}

--- a/src/main/java/com/flab/book_challenge/book/domain/Book.java
+++ b/src/main/java/com/flab/book_challenge/book/domain/Book.java
@@ -1,28 +1,30 @@
 package com.flab.book_challenge.book.domain;
 
 
+import com.flab.book_challenge.common.Auditable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @ToString
 @Getter
-public class Book {
+@Table(name = "book")
+public class Book extends Auditable {
 
     @Id
     @Include
@@ -33,7 +35,7 @@ public class Book {
     @Column(name = "book_code")
     private String bookCode;
 
-    @Column(name = "name")
+    @Column(name = "book_name")
     private String name;
 
     @Column(name = "page_count")
@@ -50,5 +52,22 @@ public class Book {
 
     public void updatePageCount(Integer pageCount) {
         this.pageCount = pageCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Book book = (Book) o;
+        return Objects.equals(id, book.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/flab/book_challenge/book/response/BookDetailResponse.java
+++ b/src/main/java/com/flab/book_challenge/book/response/BookDetailResponse.java
@@ -1,5 +1,6 @@
 package com.flab.book_challenge.book.response;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -7,6 +8,7 @@ public record BookDetailResponse(
     long id,
     String bookCode,
     String name,
-    int pageCount
+    int pageCount,
+    LocalDateTime createAt
 ) {
 }

--- a/src/main/java/com/flab/book_challenge/book/response/BookDetailResponse.java
+++ b/src/main/java/com/flab/book_challenge/book/response/BookDetailResponse.java
@@ -1,5 +1,8 @@
 package com.flab.book_challenge.book.response;
 
+import lombok.Builder;
+
+@Builder
 public record BookDetailResponse(
     long id,
     String bookCode,

--- a/src/main/java/com/flab/book_challenge/book/response/BooksResponse.java
+++ b/src/main/java/com/flab/book_challenge/book/response/BooksResponse.java
@@ -1,0 +1,15 @@
+package com.flab.book_challenge.book.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record BooksResponse(
+    int pageNumber,
+    int size,
+    long totalElementSize,
+    int totalPageSize,
+    boolean hasNext,
+    List<BookDetailResponse> data
+) {
+}

--- a/src/main/java/com/flab/book_challenge/book/service/BookService.java
+++ b/src/main/java/com/flab/book_challenge/book/service/BookService.java
@@ -1,15 +1,17 @@
 package com.flab.book_challenge.book.service;
 
+import com.flab.book_challenge.book.controller.BookSortType;
 import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
 import com.flab.book_challenge.book.response.BooksResponse;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface BookService {
 
-    BooksResponse getBooks(int page, int size);
+    BooksResponse getBooks(Pageable pageable, BookSortType sortType);
 
     List<BookDetailResponse> searchBooks(BookSearchRequest bookSearchRequest);
 

--- a/src/main/java/com/flab/book_challenge/book/service/BookService.java
+++ b/src/main/java/com/flab/book_challenge/book/service/BookService.java
@@ -4,11 +4,12 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
+import com.flab.book_challenge.book.response.BooksResponse;
 import java.util.List;
 
 public interface BookService {
 
-    List<BookDetailResponse> getBooks();
+    BooksResponse getBooks(int page, int size);
 
     List<BookDetailResponse> searchBooks(BookSearchRequest bookSearchRequest);
 

--- a/src/main/java/com/flab/book_challenge/book/service/DefaultBookService.java
+++ b/src/main/java/com/flab/book_challenge/book/service/DefaultBookService.java
@@ -6,6 +6,7 @@ import static com.flab.book_challenge.common.exception.ErrorStatus.QUERY_NOT_FOU
 
 import ch.qos.logback.core.util.StringUtil;
 import com.flab.book_challenge.book.BookMapper;
+import com.flab.book_challenge.book.controller.BookSortType;
 import com.flab.book_challenge.book.domain.Book;
 import com.flab.book_challenge.book.repository.BookRepository;
 import com.flab.book_challenge.book.request.BookCreateRequest;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,10 +45,8 @@ public class DefaultBookService implements BookService {
     }
 
     @Override
-    public BooksResponse getBooks(int page, int size) {
-
-        Pageable pageable = PageRequest.of(page, size);
-        Page<Book> bookPage = bookRepository.findAll(pageable);
+    public BooksResponse getBooks(Pageable pageable, BookSortType sortType) {
+        Page<Book> bookPage = bookRepository.findAll(getPageableWithSort(pageable, sortType));
         return BookMapper.toResponse(bookPage);
     }
 
@@ -90,6 +90,11 @@ public class DefaultBookService implements BookService {
     public void deleteBook(long bookId) {
         Book book = existsBookById(bookId);
         bookRepository.delete(book);
+    }
+
+    private Pageable getPageableWithSort(Pageable pageable, BookSortType sortType) {
+        Sort sort = BookSortType.getSort(sortType);
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
     }
 
     private Book existsBookById(long id) {

--- a/src/main/java/com/flab/book_challenge/book/service/DefaultBookService.java
+++ b/src/main/java/com/flab/book_challenge/book/service/DefaultBookService.java
@@ -12,9 +12,13 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
+import com.flab.book_challenge.book.response.BooksResponse;
 import com.flab.book_challenge.common.exception.GeneralException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,24 +43,25 @@ public class DefaultBookService implements BookService {
     }
 
     @Override
-    public List<BookDetailResponse> getBooks() {
-        return bookRepository.findAll().stream()
-            .map(book -> BookMapper.toResponse(book.getId(), book.getBookCode(), book.getName(), book.getPageCount()))
-            .toList();
+    public BooksResponse getBooks(int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Book> bookPage = bookRepository.findAll(pageable);
+        return BookMapper.toResponse(bookPage);
     }
 
     // bookCode 조회는 단일 책을, 정확한 이름 검색은 책 목록을 반환합니다.
     @Override
     public BookDetailResponse getBookByBookCode(String bookCode) {
         return bookRepository.findBookByBookCode(bookCode)
-            .map(book -> BookMapper.toResponse(book.getId(), book.getBookCode(), book.getName(), book.getPageCount()))
+            .map(BookMapper::toResponse)
             .orElseThrow(() -> new GeneralException(BOOK_NOT_FOUND));
     }
 
     @Override
     public List<BookDetailResponse> getBooksByName(String name) {
         return bookRepository.findBooksByName(name).stream()
-            .map(book -> BookMapper.toResponse(book.getId(), book.getBookCode(), book.getName(), book.getPageCount()))
+            .map(BookMapper::toResponse)
             .toList();
     }
 

--- a/src/main/java/com/flab/book_challenge/common/Auditable.java
+++ b/src/main/java/com/flab/book_challenge/common/Auditable.java
@@ -1,5 +1,6 @@
 package com.flab.book_challenge.common;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -12,9 +13,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class Auditable {
+
     @CreatedDate
-    private LocalDateTime created_at;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updated_at;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/flab/book_challenge/common/Auditable.java
+++ b/src/main/java/com/flab/book_challenge/common/Auditable.java
@@ -1,0 +1,20 @@
+package com.flab.book_challenge.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Auditable {
+    @CreatedDate
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/com/flab/book_challenge/common/exception/ErrorStatus.java
+++ b/src/main/java/com/flab/book_challenge/common/exception/ErrorStatus.java
@@ -14,7 +14,8 @@ public enum ErrorStatus {
 
     // BOOK
     BOOK_DUPLICATION(BAD_REQUEST, "BOOK_0", "이미 존재하는 책입니다."),
-    BOOK_NOT_FOUND(NOT_FOUND, "BOOK_1", "책을 찾을 수 없습니다.");
+    BOOK_NOT_FOUND(NOT_FOUND, "BOOK_1", "책을 찾을 수 없습니다."),
+    BOOK_SORT_NOT_FOUND(NOT_FOUND, "BOOK_2", "해당 정렬 조건을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/flab/book_challenge/common/header/ApiResponse.java
+++ b/src/main/java/com/flab/book_challenge/common/header/ApiResponse.java
@@ -4,19 +4,19 @@ import lombok.Getter;
 
 @Getter
 public class ApiResponse<T> {
-    private boolean success;
-    private T data;
-    private ErrorResponse error;
+    private final boolean success;
+    private final T content;
+    private final ErrorResponse error;
 
     public ApiResponse(T data) {
         this.success = true;
-        this.data = data;
+        this.content = data;
         this.error = null;
     }
 
     public ApiResponse(ErrorResponse error) {
         this.success = false;
-        this.data = null;
+        this.content = null;
         this.error = error;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -14,3 +14,7 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 100
 
+
+  sql:
+    init:
+      mode: never

--- a/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
@@ -180,5 +180,7 @@ class BookRepositoryTest {
         assertThat(actualBook.getId()).isEqualTo(expectedBook.getId());
         assertThat(actualBook.getPageCount()).isEqualTo(expectedBook.getPageCount());
         assertThat(actualBook.getName()).isEqualTo(expectedBook.getName());
+        assertThat(actualBook.getCreated_at()).isEqualTo(expectedBook.getCreated_at());
+        assertThat(actualBook.getUpdated_at()).isEqualTo(expectedBook.getUpdated_at());
     }
 }

--- a/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
@@ -180,7 +180,7 @@ class BookRepositoryTest {
         assertThat(actualBook.getId()).isEqualTo(expectedBook.getId());
         assertThat(actualBook.getPageCount()).isEqualTo(expectedBook.getPageCount());
         assertThat(actualBook.getName()).isEqualTo(expectedBook.getName());
-        assertThat(actualBook.getCreated_at()).isEqualTo(expectedBook.getCreated_at());
-        assertThat(actualBook.getUpdated_at()).isEqualTo(expectedBook.getUpdated_at());
+        assertThat(actualBook.getCreatedAt()).isEqualTo(expectedBook.getCreatedAt());
+        assertThat(actualBook.getUpdatedAt()).isEqualTo(expectedBook.getUpdatedAt());
     }
 }

--- a/src/test/java/com/flab/book_challenge/book/service/BookServiceTest.java
+++ b/src/test/java/com/flab/book_challenge/book/service/BookServiceTest.java
@@ -6,6 +6,7 @@ import static com.flab.book_challenge.common.exception.ErrorStatus.QUERY_NOT_FOU
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.flab.book_challenge.book.controller.BookSortType;
 import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,9 +50,13 @@ class BookServiceTest {
     void getBooks() {
         // given
         addRandomBooks();
+        Pageable pageable = PageRequest.of(0, 100);
+        BookSortType sortType = BookSortType.LATEST;
+
         // when
-        BooksResponse books = bookService.getBooks(0, 100);
+        BooksResponse books = bookService.getBooks(pageable, sortType);
         List<BookDetailResponse> booksContent = books.data();
+
         // then
         int randomIndex = (int) (Math.random() * 100);
 

--- a/src/test/java/com/flab/book_challenge/book/service/BookServiceTest.java
+++ b/src/test/java/com/flab/book_challenge/book/service/BookServiceTest.java
@@ -10,6 +10,7 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
+import com.flab.book_challenge.book.response.BooksResponse;
 import com.flab.book_challenge.common.exception.GeneralException;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -41,21 +42,22 @@ class BookServiceTest {
     }
 
 
-    @DisplayName("책 전체 조회")
+    @DisplayName("책 100권 조회")
     @Test
     void getBooks() {
         // given
         addRandomBooks();
         // when
-        List<BookDetailResponse> books = bookService.getBooks();
+        BooksResponse books = bookService.getBooks(0, 100);
+        List<BookDetailResponse> booksContent = books.data();
         // then
         int randomIndex = (int) (Math.random() * 100);
 
-        assertThat(books).hasSize(100);
-        assertThat(books.get(randomIndex).id()).isNotZero();
-        assertThat(books.get(randomIndex).bookCode()).isNotNull();
-        assertThat(books.get(randomIndex).name()).isNotNull();
-        assertThat(books.get(randomIndex).pageCount()).isNotZero();
+        assertThat(booksContent).hasSize(100);
+        assertThat(booksContent.get(randomIndex).id()).isNotZero();
+        assertThat(booksContent.get(randomIndex).bookCode()).isNotNull();
+        assertThat(booksContent.get(randomIndex).name()).isNotNull();
+        assertThat(booksContent.get(randomIndex).pageCount()).isNotZero();
     }
 
     @DisplayName("정상적인 bookCode를 넣었을 때 책 검색 테스트")


### PR DESCRIPTION
## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: #123, #456 -->

- #5 

## 📝 상세 내용
<!-- 변경사항에 대한 자세한 설명을 적어주세요. 왜 이런 변경이 필요했는지, 어떤 방식으로 구현했는지 등을 포함해주세요. -->

- #4  리뷰 해결
- auditing 설정 (created_at, updated_at)
- 책 조회 페이징 api 구현 및 정렬 조건 추가 
- (LATEST일땐 createdAt이 내림차순, PAGE_COUNT이 정렬조건일 땐 pageCount가 내림차순, BOOK_NAME은 오름차순)

## ☑️ CHECK_LIST

- [ ] 로컬에서 충분히 테스트 하였습니까?
- [ ] 새로운 기능에 대한 테스트 코드를 작성하였습니까?

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요. -->

성능측정을 위해 배포가 필요할 것 같습니다
