### PR TITLE
[#12] 책 조회 페이지네이션 no-offset 방식으로 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,16 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-    
+
     // test: JUnit5
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flab/book_challenge/book/BookMapper.java
+++ b/src/main/java/com/flab/book_challenge/book/BookMapper.java
@@ -2,8 +2,9 @@ package com.flab.book_challenge.book;
 
 import com.flab.book_challenge.book.domain.Book;
 import com.flab.book_challenge.book.response.BookDetailResponse;
-import com.flab.book_challenge.book.response.BooksResponse;
-import java.util.stream.Collectors;
+import com.flab.book_challenge.book.response.BooksPaginationNoOffsetResponse;
+import com.flab.book_challenge.book.response.BooksPaginationOffsetResponse;
+import java.util.List;
 import org.springframework.data.domain.Page;
 
 public final class BookMapper {
@@ -29,8 +30,8 @@ public final class BookMapper {
             .build();
     }
 
-    public static BooksResponse toResponse(Page<Book> books) {
-        return BooksResponse.builder()
+    public static BooksPaginationOffsetResponse toPaginationResponse(Page<Book> books) {
+        return BooksPaginationOffsetResponse.builder()
             .pageNumber(books.getPageable().getPageNumber())
             .size(books.getSize())
             .totalElementSize(books.getTotalElements())
@@ -38,8 +39,20 @@ public final class BookMapper {
             .hasNext(books.hasNext())
             .data(books.getContent().stream()
                 .map(BookMapper::toResponse)
-                .collect(Collectors.toList())
+                .toList()
             )
             .build();
     }
+
+    public static BooksPaginationNoOffsetResponse toPaginationResponse(List<Book> books, String next) {
+        return BooksPaginationNoOffsetResponse.builder()
+            .data(books.stream()
+                .map(BookMapper::toResponse)
+                .toList()
+            )
+            .next(next)
+            .build();
+    }
+
+
 }

--- a/src/main/java/com/flab/book_challenge/book/controller/BookController.java
+++ b/src/main/java/com/flab/book_challenge/book/controller/BookController.java
@@ -4,7 +4,8 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
-import com.flab.book_challenge.book.response.BooksResponse;
+import com.flab.book_challenge.book.response.BooksPaginationNoOffsetResponse;
+import com.flab.book_challenge.book.response.BooksPaginationOffsetResponse;
 import com.flab.book_challenge.book.service.BookService;
 import com.flab.book_challenge.common.header.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,14 +35,27 @@ public class BookController {
 
     private final BookService bookService;
 
-    @Operation(summary = "책 전체 조회 (페이징)", tags = "Book")
-    @GetMapping
-    public ResponseEntity<ApiResponse<BooksResponse>> getBooks(
+    @Operation(summary = "책 전체 조회 (페이징 레거시 - OFFSET 방식)", tags = "Book")
+    @GetMapping("/legacy")
+    public ResponseEntity<ApiResponse<BooksPaginationOffsetResponse>> getBooksByPaginationLegacy(
         @PageableDefault(size = 100) Pageable pageable,
         @RequestParam(defaultValue = "LATEST") BookSortType sortType
     ) {
-        return ResponseEntity.ok(new ApiResponse<>(bookService.getBooks(pageable, sortType)));
+        return ResponseEntity.ok(new ApiResponse<>(bookService.getBooksByPaginationLegacy(pageable, sortType)));
     }
+
+    @Operation(summary = "책 전체 조회 (페이징 - NO-OFFSET 방식)", tags = "Book")
+    @GetMapping
+    public ResponseEntity<ApiResponse<BooksPaginationNoOffsetResponse>> getBooksByPaginationNoOffset(
+        @RequestParam String sortType,
+        @RequestParam String lastValue,
+        @RequestParam(defaultValue = "false") boolean isAscending,
+        @RequestParam(defaultValue = "10") int limit
+    ) {
+        return ResponseEntity.ok(
+            new ApiResponse<>(bookService.getBooksByPaginationNoOffset(sortType, lastValue, isAscending, limit)));
+    }
+
 
     @Operation(summary = "책 검색", tags = "Book")
     @GetMapping("/search")
@@ -50,7 +64,7 @@ public class BookController {
     ) {
         return ResponseEntity.ok(new ApiResponse<>(bookService.searchBooks(bookSearchRequest)));
     }
-    
+
     @Operation(summary = "책 아이디 검색", tags = "Book")
     @GetMapping("/search/{id}")
     public ResponseEntity<ApiResponse<BookDetailResponse>> searchBookById(

--- a/src/main/java/com/flab/book_challenge/book/controller/BookSortType.java
+++ b/src/main/java/com/flab/book_challenge/book/controller/BookSortType.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Sort;
 
 public enum BookSortType {
     LATEST,
+    CREATED_AT,
     PAGE_COUNT,
     BOOK_NAME;
 
@@ -15,6 +16,15 @@ public enum BookSortType {
             case LATEST -> Sort.by(Sort.Direction.DESC, "createdAt");
             case PAGE_COUNT -> Sort.by(Sort.Direction.DESC, "pageCount");
             case BOOK_NAME -> Sort.by(Sort.Direction.ASC, "name");
+            default -> throw new GeneralException(BOOK_SORT_NOT_FOUND);
+        };
+    }
+
+    public static BookSortType from(String sortType) {
+        return switch (sortType.toUpperCase()) {
+            case "CREATED_AT" -> CREATED_AT;
+            case "PAGE_COUNT" -> PAGE_COUNT;
+            case "BOOK_NAME" -> BOOK_NAME;
             default -> throw new GeneralException(BOOK_SORT_NOT_FOUND);
         };
     }

--- a/src/main/java/com/flab/book_challenge/book/repository/BookRepository.java
+++ b/src/main/java/com/flab/book_challenge/book/repository/BookRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BookRepository extends JpaRepository<Book, Long> {
+public interface BookRepository extends JpaRepository<Book, Long>, BookRepositoryCustom {
     Optional<Book> findBookByBookCode(String bookCode);
 
     List<Book> findBooksByNameContaining(String name);

--- a/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustom.java
+++ b/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustom.java
@@ -5,5 +5,5 @@ import com.flab.book_challenge.book.service.SortCondition;
 import java.util.List;
 
 public interface BookRepositoryCustom {
-    List<Book> findBooksNoOffset(SortCondition<?> sortCondition, int limit);
+    List<Book> findBooksNoOffset(SortCondition sortCondition, int limit);
 }

--- a/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustom.java
+++ b/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.flab.book_challenge.book.repository;
+
+import com.flab.book_challenge.book.domain.Book;
+import com.flab.book_challenge.book.service.SortCondition;
+import java.util.List;
+
+public interface BookRepositoryCustom {
+    List<Book> findBooksNoOffset(SortCondition<?> sortCondition, int limit);
+}

--- a/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustomImpl.java
@@ -19,24 +19,24 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class BookRepositoryCustomImpl implements BookRepositoryCustom {
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Book> findBooksNoOffset(SortCondition<?> sortCondition, int limit) {
+    public List<Book> findBooksNoOffset(SortCondition sortCondition, int limit) {
 
         switch (sortCondition.sortField()) {
             case CREATED_AT -> {
-                LocalDateTime lastDateTime = LocalDateTime.parse((String) sortCondition.lastValue(), formatter);
+                LocalDateTime lastDateTime = LocalDateTime.parse(sortCondition.lastValue(), formatter);
                 return findBooksByLocalDateTime(lastDateTime, sortCondition.isAscending(),
                     limit);
             }
             case PAGE_COUNT -> {
-                return findBooksByPageCount(Integer.parseInt((String) sortCondition.lastValue()),
+                return findBooksByPageCount(Integer.parseInt(sortCondition.lastValue()),
                     sortCondition.isAscending(), limit);
             }
             case BOOK_NAME -> {
-                return findBooksByBookName((String) sortCondition.lastValue(), sortCondition.isAscending(), limit);
+                return findBooksByBookName(sortCondition.lastValue(), sortCondition.isAscending(), limit);
             }
             default -> throw new GeneralException(BOOK_SORT_NOT_FOUND);
         }

--- a/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/com/flab/book_challenge/book/repository/BookRepositoryCustomImpl.java
@@ -1,0 +1,86 @@
+package com.flab.book_challenge.book.repository;
+
+import static com.flab.book_challenge.common.exception.ErrorStatus.BOOK_SORT_NOT_FOUND;
+
+import com.flab.book_challenge.book.domain.Book;
+import com.flab.book_challenge.book.domain.QBook;
+import com.flab.book_challenge.book.service.SortCondition;
+import com.flab.book_challenge.common.exception.GeneralException;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookRepositoryCustomImpl implements BookRepositoryCustom {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Book> findBooksNoOffset(SortCondition<?> sortCondition, int limit) {
+
+        switch (sortCondition.sortField()) {
+            case CREATED_AT -> {
+                LocalDateTime lastDateTime = LocalDateTime.parse((String) sortCondition.lastValue(), formatter);
+                return findBooksByLocalDateTime(lastDateTime, sortCondition.isAscending(),
+                    limit);
+            }
+            case PAGE_COUNT -> {
+                return findBooksByPageCount(Integer.parseInt((String) sortCondition.lastValue()),
+                    sortCondition.isAscending(), limit);
+            }
+            case BOOK_NAME -> {
+                return findBooksByBookName((String) sortCondition.lastValue(), sortCondition.isAscending(), limit);
+            }
+            default -> throw new GeneralException(BOOK_SORT_NOT_FOUND);
+        }
+
+    }
+
+    private List<Book> findBooksByLocalDateTime(LocalDateTime lastCreatedAt, boolean isAscending, int limit) {
+        QBook book = QBook.book;
+
+        BooleanExpression l = isAscending ? book.createdAt.gt(lastCreatedAt) : book.createdAt.lt(lastCreatedAt);
+        OrderSpecifier<LocalDateTime> isAsc = isAscending ? book.createdAt.asc() : book.createdAt.desc();
+
+        return queryFactory
+            .selectFrom(book)
+            .where(l)
+            .orderBy(isAsc)
+            .limit(limit)
+            .fetch();
+    }
+
+    private List<Book> findBooksByBookName(String lastBookName, boolean isAscending, int limit) {
+        QBook book = QBook.book;
+
+        BooleanExpression l = isAscending ? book.name.gt(lastBookName) : book.name.lt(lastBookName);
+        OrderSpecifier<String> isAsc = isAscending ? book.name.asc() : book.name.desc();
+
+        return queryFactory
+            .selectFrom(book)
+            .where(l)
+            .orderBy(isAsc)
+            .limit(limit)
+            .fetch();
+    }
+
+    private List<Book> findBooksByPageCount(int lastPageCount, boolean isAscending, int limit) {
+        QBook book = QBook.book;
+        BooleanExpression l = isAscending ? book.pageCount.gt(lastPageCount) : book.pageCount.lt(lastPageCount);
+        OrderSpecifier<Integer> isAsc = isAscending ? book.pageCount.asc() : book.pageCount.desc();
+
+        return queryFactory
+            .selectFrom(book)
+            .where(l)
+            .orderBy(isAsc)
+            .limit(limit)
+            .fetch();
+    }
+}

--- a/src/main/java/com/flab/book_challenge/book/response/BooksPaginationNoOffsetResponse.java
+++ b/src/main/java/com/flab/book_challenge/book/response/BooksPaginationNoOffsetResponse.java
@@ -1,0 +1,11 @@
+package com.flab.book_challenge.book.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record BooksPaginationNoOffsetResponse(
+    List<BookDetailResponse> data,
+    String next
+) {
+}

--- a/src/main/java/com/flab/book_challenge/book/response/BooksPaginationOffsetResponse.java
+++ b/src/main/java/com/flab/book_challenge/book/response/BooksPaginationOffsetResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record BooksResponse(
+public record BooksPaginationOffsetResponse(
     int pageNumber,
     int size,
     long totalElementSize,

--- a/src/main/java/com/flab/book_challenge/book/service/BookService.java
+++ b/src/main/java/com/flab/book_challenge/book/service/BookService.java
@@ -5,7 +5,8 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
-import com.flab.book_challenge.book.response.BooksResponse;
+import com.flab.book_challenge.book.response.BooksPaginationNoOffsetResponse;
+import com.flab.book_challenge.book.response.BooksPaginationOffsetResponse;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
@@ -13,9 +14,12 @@ public interface BookService {
 
     BookDetailResponse getBookById(Long id);
 
-    BooksResponse getBooks(Pageable pageable, BookSortType sortType);
+    BooksPaginationOffsetResponse getBooksByPaginationLegacy(Pageable pageable, BookSortType sortType);
 
     List<BookDetailResponse> searchBooks(BookSearchRequest bookSearchRequest);
+
+    BooksPaginationNoOffsetResponse getBooksByPaginationNoOffset(String sort, String lastValue, boolean isAscending,
+                                                                 int limit);
 
     BookDetailResponse getBookByBookCode(String bookCode);
 

--- a/src/main/java/com/flab/book_challenge/book/service/DefaultBookService.java
+++ b/src/main/java/com/flab/book_challenge/book/service/DefaultBookService.java
@@ -64,17 +64,17 @@ public class DefaultBookService implements BookService {
     @Override
     public BooksPaginationNoOffsetResponse getBooksByPaginationNoOffset(String sort, String lastValue,
                                                                         boolean isAscending, int limit) {
-        SortCondition<?> sortCondition = this.createSortCondition(BookSortType.from(sort), lastValue, isAscending);
+        SortCondition sortCondition = this.createSortCondition(BookSortType.from(sort), lastValue, isAscending);
         List<Book> books = bookRepository.findBooksNoOffset(sortCondition, limit);
 
-        String next = null;
+        String nextURL = null;
         if (!books.isEmpty()) {
             Book lastBook = books.getLast();
             String nextLastValue = getNextLastValue(lastBook, BookSortType.from(sort));
-            next = buildNextPageUrl(sort, nextLastValue, isAscending, limit);
+            nextURL = buildNextPageUrl(sort, nextLastValue, isAscending, limit);
         }
 
-        return BookMapper.toPaginationResponse(books, next);
+        return BookMapper.toPaginationResponse(books, nextURL);
 
     }
 
@@ -146,7 +146,7 @@ public class DefaultBookService implements BookService {
     }
 
 
-    private SortCondition<?> createSortCondition(BookSortType sortType, String lastValue, boolean isAscending) {
+    private SortCondition createSortCondition(BookSortType sortType, String lastValue, boolean isAscending) {
         return SortCondition.by(isAscending, sortType, lastValue);
     }
 

--- a/src/main/java/com/flab/book_challenge/book/service/SortCondition.java
+++ b/src/main/java/com/flab/book_challenge/book/service/SortCondition.java
@@ -1,0 +1,12 @@
+package com.flab.book_challenge.book.service;
+
+import com.flab.book_challenge.book.controller.BookSortType;
+
+
+public record SortCondition<T>(boolean isAscending, BookSortType sortField, T lastValue) {
+
+    public static <T> SortCondition<T> by(boolean isAscending, BookSortType sortField, T lastValue) {
+        return new SortCondition<>(isAscending, sortField, lastValue);
+    }
+
+}

--- a/src/main/java/com/flab/book_challenge/book/service/SortCondition.java
+++ b/src/main/java/com/flab/book_challenge/book/service/SortCondition.java
@@ -3,10 +3,10 @@ package com.flab.book_challenge.book.service;
 import com.flab.book_challenge.book.controller.BookSortType;
 
 
-public record SortCondition<T>(boolean isAscending, BookSortType sortField, T lastValue) {
+public record SortCondition(boolean isAscending, BookSortType sortField, String lastValue) {
 
-    public static <T> SortCondition<T> by(boolean isAscending, BookSortType sortField, T lastValue) {
-        return new SortCondition<>(isAscending, sortField, lastValue);
+    public static SortCondition by(boolean isAscending, BookSortType sortField, String lastValue) {
+        return new SortCondition(isAscending, sortField, lastValue);
     }
 
 }

--- a/src/main/java/com/flab/book_challenge/common/config/QuerydslConfiguration.java
+++ b/src/main/java/com/flab/book_challenge/common/config/QuerydslConfiguration.java
@@ -1,0 +1,18 @@
+package com.flab.book_challenge.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfiguration {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/flab/book_challenge/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/flab/book_challenge/common/exception/ExceptionControllerAdvice.java
@@ -1,8 +1,11 @@
 package com.flab.book_challenge.common.exception;
 
+import static com.flab.book_challenge.common.exception.ErrorStatus.getHttpStatusByCode;
+
 import com.flab.book_challenge.common.header.ApiResponse;
 import com.flab.book_challenge.common.header.ErrorResponse;
 import jakarta.validation.ConstraintViolationException;
+import java.time.format.DateTimeParseException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,11 +18,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class ExceptionControllerAdvice {
 
+    private static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
+    private static final String INVALID_INPUT = "INVALID_INPUT";
+
     @ExceptionHandler(GeneralException.class)
     public ResponseEntity<?> handleGeneralException(GeneralException e) {
         log.warn("[API ERROR]: {}", e.getMessage());
         ErrorResponse errorResponse = new ErrorResponse(e.getCode(), e.getMessage());
-        HttpStatus status = ErrorStatus.getHttpStatusByCode(e.getCode());
+        HttpStatus status = getHttpStatusByCode(e.getCode());
 
         return ResponseEntity.status(status).body(new ApiResponse<>(errorResponse));
     }
@@ -32,7 +38,7 @@ public class ExceptionControllerAdvice {
 
         log.error("[Validation ERROR]: {}", errorMessage);
 
-        ErrorResponse errorResponse = new ErrorResponse("INVALID_INPUT", errorMessage);
+        ErrorResponse errorResponse = new ErrorResponse(INVALID_INPUT, errorMessage);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>(errorResponse));
     }
@@ -45,14 +51,21 @@ public class ExceptionControllerAdvice {
 
         log.error("[Constraint violation]: {}", errorMessage);
 
-        ErrorResponse errorResponse = new ErrorResponse("INVALID_INPUT", errorMessage);
+        ErrorResponse errorResponse = new ErrorResponse(INVALID_INPUT, errorMessage);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>(errorResponse));
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<?> handleDateTimeParseException(DateTimeParseException e) {
+        log.error("[DateTime parse error]: ", e);
+        ErrorResponse errorResponse = new ErrorResponse(INVALID_INPUT, "Invalid date time format");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>(errorResponse));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleGeneralException(Exception e) {
         log.error("[Unexpected error occurred]: ", e);
-        ErrorResponse errorResponse = new ErrorResponse("INTERNAL_SERVER_ERROR", "An unexpected error occurred");
+        ErrorResponse errorResponse = new ErrorResponse(INTERNAL_SERVER_ERROR, "An unexpected error occurred");
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiResponse<>(errorResponse));
     }
 

--- a/src/main/java/com/flab/book_challenge/common/util/ServerUrlComponent.java
+++ b/src/main/java/com/flab/book_challenge/common/util/ServerUrlComponent.java
@@ -1,0 +1,25 @@
+package com.flab.book_challenge.common.util;
+
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@Getter
+public class ServerUrlComponent {
+    @Value("${server.url}")
+    private String url;
+
+    private ServerUrlComponent() {
+    }
+
+    public String buildURL(String path, Map<String, Object> params) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(url + path);
+        params.forEach(builder::queryParam);
+
+        return builder.build().toUriString();
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,3 +31,7 @@ logging:
     org.hibernate.SQL: debug
     root: info
     org.hibernate.orm.jdbc.bind: trace
+
+server:
+  url: http://localhost:8080
+  port: 8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,8 +20,14 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show_sql: true
+        show_sql: false
         use_sql_comments: true
         default_batch_fetch_size: 100
     defer-datasource-initialization: true
     open-in-view: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    root: info
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,3 +25,7 @@ spring:
         default_batch_fetch_size: 100
     defer-datasource-initialization: true
     open-in-view: false
+
+server:
+  url: ${PROD_SERVER_URL}
+  port: 8080

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -18,3 +18,7 @@ spring:
   sql:
     init:
       mode: never
+
+server:
+  url: http://localhost:8080
+  port: 8080

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,7 +12,7 @@
     <!--local-->
     <springProfile name="local">
         <include resource="console-appender.xml"/>
-        <root level="INFO">
+        <root level="TRACE">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>

--- a/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
@@ -2,7 +2,9 @@ package com.flab.book_challenge.book.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.flab.book_challenge.book.controller.BookSortType;
 import com.flab.book_challenge.book.domain.Book;
+import com.flab.book_challenge.book.service.SortCondition;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -34,6 +36,32 @@ class BookRepositoryTest {
             .name("test_book")
             .pageCount(randomCount)
             .build();
+
+    }
+
+    @DisplayName("No-Offset 방식으로 책 페이지 큰것 크기순 조회 테스트")
+    @Test
+    void testFindBooksNoOffset() {
+        // given
+        ArrayList<Book> books = new ArrayList<>(100);
+        makeBooks(books);
+        bookRepository.saveAll(books);
+
+        SortCondition<Integer> firstTest = SortCondition.by(false, BookSortType.PAGE_COUNT,
+            50);
+        SortCondition<Integer> secondTest = SortCondition.by(false, BookSortType.PAGE_COUNT,
+            10);
+
+        // when
+        List<Book> firstBooks = bookRepository.findBooksNoOffset(firstTest, 10);
+        List<Book> secondBooks = bookRepository.findBooksNoOffset(secondTest, 10);
+
+        // then
+        assertThat(firstBooks).hasSize(10);
+        assertThat(secondBooks).hasSize(10);
+        assertThat(firstBooks.getFirst().getPageCount()).isEqualTo(49);
+        assertThat(firstBooks.get(1).getPageCount()).isEqualTo(48);
+        assertThat(secondBooks.getFirst().getPageCount()).isEqualTo(9);
 
     }
 
@@ -174,12 +202,12 @@ class BookRepositoryTest {
     private void makeBooks(ArrayList<Book> books) {
         for (int i = 0; i < 100; i++) {
             String randomBookCode = RandomStringUtils.randomNumeric(13);
-            int randomCount = (int) (Math.random() * 101) + 100;
+
             Book book;
             book = Book.builder()
                 .bookCode(randomBookCode)
                 .name("test_book")
-                .pageCount(randomCount)
+                .pageCount(i)
                 .build();
 
             books.add(book);

--- a/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/flab/book_challenge/book/repository/BookRepositoryTest.java
@@ -47,10 +47,10 @@ class BookRepositoryTest {
         makeBooks(books);
         bookRepository.saveAll(books);
 
-        SortCondition<Integer> firstTest = SortCondition.by(false, BookSortType.PAGE_COUNT,
-            50);
-        SortCondition<Integer> secondTest = SortCondition.by(false, BookSortType.PAGE_COUNT,
-            10);
+        SortCondition firstTest = SortCondition.by(false, BookSortType.PAGE_COUNT,
+            "50");
+        SortCondition secondTest = SortCondition.by(false, BookSortType.PAGE_COUNT,
+            "10");
 
         // when
         List<Book> firstBooks = bookRepository.findBooksNoOffset(firstTest, 10);

--- a/src/test/java/com/flab/book_challenge/book/service/BookServiceTest.java
+++ b/src/test/java/com/flab/book_challenge/book/service/BookServiceTest.java
@@ -11,7 +11,7 @@ import com.flab.book_challenge.book.request.BookCreateRequest;
 import com.flab.book_challenge.book.request.BookSearchRequest;
 import com.flab.book_challenge.book.request.BookUpdateRequest;
 import com.flab.book_challenge.book.response.BookDetailResponse;
-import com.flab.book_challenge.book.response.BooksResponse;
+import com.flab.book_challenge.book.response.BooksPaginationOffsetResponse;
 import com.flab.book_challenge.common.exception.GeneralException;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -54,7 +54,7 @@ class BookServiceTest {
         BookSortType sortType = BookSortType.LATEST;
 
         // when
-        BooksResponse books = bookService.getBooks(pageable, sortType);
+        BooksPaginationOffsetResponse books = bookService.getBooksByPaginationLegacy(pageable, sortType);
         List<BookDetailResponse> booksContent = books.data();
 
         // then


### PR DESCRIPTION
## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: #123, #456 -->
- #12 
## 📝 상세 내용
<!-- 변경사항에 대한 자세한 설명을 적어주세요. 왜 이런 변경이 필요했는지, 어떤 방식으로 구현했는지 등을 포함해주세요. -->
- 특정 칼럼에 인덱스를 거는 것만으로는 페이지가 넘어갈 수록 offset 자체의 문제 때문에 (이전꺼도 다 읽기 때문) 성능이 여전히 안좋습니다
- 커버링 인덱스는 많은 인덱스를 생성해야 하는 점, 앞으로 칼럼이 추가될 가능성도 배제할 수 없기 때문에 인덱스를 업데이트 할 수 있다는 점, 많은 인덱스는 또 INSERT 등 쿼리 성능에 저하될 수 있다는 단점때문에 NO-OFFSET 방식으로 성능을 개선했습니다.
- 더 자세한 내용과 사진은 이슈란에 추가했습니다.
- 다음은 NO-OFFSET 방식으로 구현하고 쿼리 익스프레인과 duration 값입니다.
![image](https://github.com/user-attachments/assets/ab95e7af-d00e-4c68-b184-6c34e9fb6489)
   - duration: 0.00060275
![image](https://github.com/user-attachments/assets/247a4b34-05e9-4912-af9c-3acb6c22e512)
- 이를 구현하기 위해 querydsl 사용과 좀더 다양한 정렬조건이 유연하게 동작하도록 설계했습니다.

## ☑️ CHECK_LIST

- [x] 로컬에서 충분히 테스트 하였습니까?
- [x] 새로운 기능에 대한 테스트 코드를 작성하였습니까?

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요. -->
